### PR TITLE
Springboot 3.3.3 migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <mock.web.server.version>4.6.0</mock.web.server.version>
         <wiremock.version>3.9.1</wiremock.version>
         <powsybl-dependencies.version>2024.2.0</powsybl-dependencies.version>
-        <powsybl-case-datasource-client.version>1.9.1</powsybl-case-datasource-client.version>
+        <powsybl-case-datasource-client.version>11.10.0</powsybl-case-datasource-client.version>
         <powsybl-network-store-client.version>1.14.1</powsybl-network-store-client.version>
         <powsybl-ws-commons.version>1.14.0</powsybl-ws-commons.version>
         <spring-cloud.version>2023.0.3</spring-cloud.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <!-- FIXME: upgrade to spring-cloud: 2023.0.4 when it is available -->
         <!-- versions 2023.0.2 and 2023.0.3 of spring-cloud cause the following problem : https://github.com/spring-cloud/spring-cloud-stream/issues/2988 -->
         <spring-cloud.version>2023.0.1</spring-cloud.version>
-        <springboot.version>3.3.2</springboot.version>
+        <springboot.version>3.3.3</springboot.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
         <springdoc-openapi-starter-webflux-ui.version>2.1.0</springdoc-openapi-starter-webflux-ui.version>
         <websocket-tyrus.version>2.1.2</websocket-tyrus.version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
             <dependency>
                 <groupId>org.wiremock</groupId>
                 <artifactId>wiremock-jetty12</artifactId>
-                <version>3.9.1</version>
+                <version>${wiremock.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.powsybl</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,9 +53,9 @@
         <mock.web.server.version>4.6.0</mock.web.server.version>
         <wiremock.version>3.9.1</wiremock.version>
         <powsybl-dependencies.version>2024.2.0</powsybl-dependencies.version>
-        <powsybl-case-datasource-client.version>1.9.0</powsybl-case-datasource-client.version>
-        <powsybl-network-store-client.version>1.14.0</powsybl-network-store-client.version>
-        <powsybl-ws-commons.version>1.12.0</powsybl-ws-commons.version>
+        <powsybl-case-datasource-client.version>1.9.1</powsybl-case-datasource-client.version>
+        <powsybl-network-store-client.version>1.14.1</powsybl-network-store-client.version>
+        <powsybl-ws-commons.version>1.12.1</powsybl-ws-commons.version>
         <spring-cloud.version>2023.0.3</spring-cloud.version>
         <springboot.version>3.3.2</springboot.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,13 +51,13 @@
     <properties>
         <lombok.version>1.18.24</lombok.version>
         <mock.web.server.version>4.6.0</mock.web.server.version>
-        <wiremock.version>3.0.4</wiremock.version>
+        <wiremock.version>3.9.1</wiremock.version>
         <powsybl-dependencies.version>2024.2.0</powsybl-dependencies.version>
         <powsybl-case-datasource-client.version>1.9.0</powsybl-case-datasource-client.version>
         <powsybl-network-store-client.version>1.14.0</powsybl-network-store-client.version>
         <powsybl-ws-commons.version>1.12.0</powsybl-ws-commons.version>
-        <spring-cloud.version>2022.0.3</spring-cloud.version>
-        <springboot.version>3.1.2</springboot.version>
+        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <springboot.version>3.3.2</springboot.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
         <springdoc-openapi-starter-webflux-ui.version>2.1.0</springdoc-openapi-starter-webflux-ui.version>
         <websocket-tyrus.version>2.1.2</websocket-tyrus.version>
@@ -110,8 +110,8 @@
             </dependency>
             <dependency>
                 <groupId>org.wiremock</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>${wiremock.version}</version>
+                <artifactId>wiremock-jetty12</artifactId>
+                <version>3.9.1</version>
             </dependency>
             <dependency>
                 <groupId>com.powsybl</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,10 +53,10 @@
         <mock.web.server.version>4.6.0</mock.web.server.version>
         <wiremock.version>3.9.1</wiremock.version>
         <powsybl-dependencies.version>2024.2.0</powsybl-dependencies.version>
-        <powsybl-case-datasource-client.version>1.10.0</powsybl-case-datasource-client.version>
-        <powsybl-network-store-client.version>1.14.1</powsybl-network-store-client.version>
-        <powsybl-ws-commons.version>1.14.0</powsybl-ws-commons.version>
-        <spring-cloud.version>2023.0.3</spring-cloud.version>
+        <powsybl-case-datasource-client.version>1.9.0</powsybl-case-datasource-client.version>
+        <powsybl-network-store-client.version>1.14.0</powsybl-network-store-client.version>
+        <powsybl-ws-commons.version>1.13.0</powsybl-ws-commons.version>
+        <spring-cloud.version>2023.0.1</spring-cloud.version>
         <springboot.version>3.3.2</springboot.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>
         <springdoc-openapi-starter-webflux-ui.version>2.1.0</springdoc-openapi-starter-webflux-ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     </parent>
 
     <artifactId>powsybl-ws-dependencies</artifactId>
-    <version>2.13.0-SNAPSHOT</version>
+    <version>2.13.0</version>
     <packaging>pom</packaging>
 
     <name>PowSyBl Web Services Dependencies</name>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@
         <powsybl-case-datasource-client.version>1.9.0</powsybl-case-datasource-client.version>
         <powsybl-network-store-client.version>1.14.0</powsybl-network-store-client.version>
         <powsybl-ws-commons.version>1.13.0</powsybl-ws-commons.version>
+
+        <!-- FIXME: upgrade to spring-cloud: 2023.0.4 when it is available -->
+        <!-- versions 2023.0.2 and 2023.0.3 of spring-cloud cause the following problem : https://github.com/spring-cloud/spring-cloud-stream/issues/2988 -->
         <spring-cloud.version>2023.0.1</spring-cloud.version>
         <springboot.version>3.3.2</springboot.version>
         <springdoc-openapi-starter-webmvc-ui.version>2.1.0</springdoc-openapi-starter-webmvc-ui.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <mock.web.server.version>4.6.0</mock.web.server.version>
         <wiremock.version>3.9.1</wiremock.version>
         <powsybl-dependencies.version>2024.2.0</powsybl-dependencies.version>
-        <powsybl-case-datasource-client.version>11.10.0</powsybl-case-datasource-client.version>
+        <powsybl-case-datasource-client.version>1.10.0</powsybl-case-datasource-client.version>
         <powsybl-network-store-client.version>1.14.1</powsybl-network-store-client.version>
         <powsybl-ws-commons.version>1.14.0</powsybl-ws-commons.version>
         <spring-cloud.version>2023.0.3</spring-cloud.version>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Spring boot 3.3.3 migration

Migration of spring cloud to a version supported by the new spring boot 3.3.3: 2023.0.1 (https://spring.io/projects/spring-cloud).
Spring-cloud 2023.0.2 and 2023.0.3 cause this problem with new springboot version : https://github.com/spring-cloud/spring-cloud-stream/issues/2988

The new spring boot version use jetty12 which cause issues with wiremock that use jetty11 (https://github.com/wiremock/wiremock/issues/2395) ==> change to new wiremock dependency that support jetty12: wiremock-jetty12(https://wiremock.org/docs/jetty-12/) 
