### PR TITLE
Upgrade lombok 1.18.24 -> 1.18.34 (jdk 21 support)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     </scm>
 
     <properties>
-        <lombok.version>1.18.24</lombok.version>
+        <lombok.version>1.18.34</lombok.version>
         <mock.web.server.version>4.6.0</mock.web.server.version>
         <wiremock.version>3.9.1</wiremock.version>
         <powsybl-dependencies.version>2024.4.0</powsybl-dependencies.version>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dep upgrade

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
lombok incomatible with jdk21


**What is the new behavior (if this is a feature change)?**
lombok compatible with jdk21


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
We choose lombok 1.18.34 like in springboot-dependencies 3.3.3 that we are currently using

Maybe we should delegate entirely to springboot the version of lombok? But contrary to other dependencies, lombok is a build only tool tied to our source code so it makes sense to handle differently but in practice we didn't upgrade it until we were forced to by java 21

Not sure why it was added initialy by me in
https://github.com/gridsuite/dependencies/commit/9abee85fe4585a6bca2dc0f18261045f09e9ea0b maybe just because it's a compile tool.
